### PR TITLE
JWT validation is sending 2 Authorization headers causing a HTTP 400 …

### DIFF
--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -2287,7 +2287,12 @@ class FusionAuthClient
    */
   public function validateJWT($encodedJWT)
   {
-    return $this->start()->uri("/api/jwt/validate")
+    $rest = new RESTClient();
+    return $rest->url($this->baseURL)
+        ->connectTimeout($this->connectTimeout)
+        ->readTimeout($this->readTimeout)
+        ->successResponseHandler(new JSONResponseHandler())
+        ->errorResponseHandler(new JSONResponseHandler())->uri("/api/jwt/validate")
         ->authorization("JWT " . $encodedJWT)
         ->get()
         ->go();


### PR DESCRIPTION
JWT validation is sending 2 Authorization headers causing a HTTP 400 error
Sending only the JWT Authorization header works fine.
This could possibly an issue with the other JWT methods but I haven't tested that.