### PR TITLE
Update README.md so that noobs don't get confused

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require fusionauth/fusionauth-client
 
 ```PHP
 $apiKey = "5a826da2-1e3a-49df-85ba-cd88575e4e9d";
-$client = new FusionAuthClient($apiKey, "http://localhost:9011");
+$client = new FusionAuth\FusionAuthClient($apiKey, "http://localhost:9011");
 ```
 
 #### Login a user


### PR DESCRIPTION
Noobs trying to use the lib will be getting confused by the missing namespace in the new statement, and without it, the example is incorrect anyway, so I recommend adding it to avoid confusing noobs as well as to have the example be actually correct.

https://stackoverflow.com/questions/56372452/how-do-i-solve-fusionauth-php-client-error-fusionauthclient-not-found/56377080#56377080