### PR TITLE
Removed unnessecary includes.

### DIFF
--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -41,11 +41,6 @@ class FusionAuthClient
   private $baseURL;
 
   /**
-   * @var string
-   */
-  private $tenantId;
-
-  /**
    * @var int
    */
   public $connectTimeout = 2000;
@@ -57,13 +52,9 @@ class FusionAuthClient
 
   public function __construct($apiKey, $baseURL)
   {
+    //include_once 'RESTClient.php';
     $this->apiKey = $apiKey;
     $this->baseURL = $baseURL;
-  }
-
-  public function withTenantId($tenantId) {
-    $this->tenantId = $tenantId;
-    return $this;
   }
 
   /**
@@ -2899,10 +2890,7 @@ class FusionAuthClient
 
   private function start()
   {
-    $rest = new RESTClient();
-    if (isset($tenantId)) {
-      $rest->header("X-FusionAuth-TenantId", $tenantId);
-    }
+    $rest = new \FusionAuth\RESTClient();
     return $rest->authorization($this->apiKey)
         ->url($this->baseURL)
         ->connectTimeout($this->connectTimeout)

--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -2888,7 +2888,7 @@ class FusionAuthClient
         ->go();
   }
 
-  private function start()
+  protected function start()
   {
     $rest = new RESTClient();
     return $rest->authorization($this->apiKey)

--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -57,7 +57,6 @@ class FusionAuthClient
 
   public function __construct($apiKey, $baseURL)
   {
-    include_once 'RESTClient.php';
     $this->apiKey = $apiKey;
     $this->baseURL = $baseURL;
   }

--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -2890,7 +2890,7 @@ class FusionAuthClient
 
   private function start()
   {
-    $rest = new \FusionAuth\RESTClient();
+    $rest = new RESTClient();
     return $rest->authorization($this->apiKey)
         ->url($this->baseURL)
         ->connectTimeout($this->connectTimeout)

--- a/src/FusionAuth/JSONBodyHandler.php
+++ b/src/FusionAuth/JSONBodyHandler.php
@@ -1,0 +1,53 @@
+<?php
+namespace FusionAuth;
+
+class JSONBodyHandler implements BodyHandler
+{
+  private $body;
+
+  private $bodyObject;
+
+  public function __construct(&$bodyObject)
+  {
+    $this->bodyObject = $bodyObject;
+    $this->body = json_encode(array_filter($bodyObject));
+  }
+
+  public function body()
+  {
+    return $this->body;
+  }
+
+  public function bodyObject()
+  {
+    return $this->bodyObject;
+  }
+
+  public function setHeaders(&$headers)
+  {
+    $headers[] = 'Content-Length: ' . strlen($this->body);
+    $headers[] = 'Content-Type: application/json';
+  }
+}
+
+interface BodyHandler
+{
+  /**
+   * @return string The body as a string.
+   */
+  public function body();
+
+  /**
+   * @return mixed The body as an object (usually an array).
+   */
+  public function bodyObject();
+
+  /**
+   * Sets body handler specific headers (like Content-Type).
+   *
+   * @param array $headers The headers array to add headers to.
+   */
+  public function setHeaders(&$headers);
+}
+
+

--- a/src/FusionAuth/JSONResponseHandler.php
+++ b/src/FusionAuth/JSONResponseHandler.php
@@ -1,0 +1,24 @@
+<?php
+namespace FusionAuth;
+
+
+
+
+class JSONResponseHandler implements ResponseHandler
+{
+  public function call(&$response)
+  {
+    return json_decode($response);
+  }
+}
+
+interface ResponseHandler
+{
+  /**
+   * Handles the HTTP response.
+   *
+   * @param string $response The HTTP response as a String.
+   * @return mixed The response as an object.
+   */
+  public function call(&$response);
+}

--- a/src/FusionAuth/RESTClient.php
+++ b/src/FusionAuth/RESTClient.php
@@ -162,7 +162,7 @@ class RESTClient
     if (!$this->url || (bool)parse_url($this->url, PHP_URL_HOST) === FALSE) {
       throw new \Exception('You must specify a URL');
     }
-
+	  
     if (!$this->method) {
       throw new \Exception('You must specify a HTTP method');
     }
@@ -348,73 +348,5 @@ class RESTClient
       $this->url = $this->url . $value;
     }
     return $this;
-  }
-}
-
-interface BodyHandler
-{
-  /**
-   * @return string The body as a string.
-   */
-  public function body();
-
-  /**
-   * @return mixed The body as an object (usually an array).
-   */
-  public function bodyObject();
-
-  /**
-   * Sets body handler specific headers (like Content-Type).
-   *
-   * @param array $headers The headers array to add headers to.
-   */
-  public function setHeaders(&$headers);
-}
-
-class JSONBodyHandler implements BodyHandler
-{
-  private $body;
-
-  private $bodyObject;
-
-  public function __construct(&$bodyObject)
-  {
-    $this->bodyObject = $bodyObject;
-    $this->body = json_encode(array_filter($bodyObject));
-  }
-
-  public function body()
-  {
-    return $this->body;
-  }
-
-  public function bodyObject()
-  {
-    return $this->bodyObject;
-  }
-
-  public function setHeaders(&$headers)
-  {
-    $headers[] = 'Content-Length: ' . strlen($this->body);
-    $headers[] = 'Content-Type: application/json';
-  }
-}
-
-interface ResponseHandler
-{
-  /**
-   * Handles the HTTP response.
-   *
-   * @param string $response The HTTP response as a String.
-   * @return mixed The response as an object.
-   */
-  public function call(&$response);
-}
-
-class JSONResponseHandler implements ResponseHandler
-{
-  public function call(&$response)
-  {
-    return json_decode($response);
   }
 }

--- a/src/FusionAuth/RESTClient.php
+++ b/src/FusionAuth/RESTClient.php
@@ -81,7 +81,7 @@ class RESTClient
 
   public function __construct()
   {
-    include_once 'ClientResponse.php';
+    
   }
 
   public function authorization($key)


### PR DESCRIPTION
the FusionAuthClient and RESTClient.php contained 'include_once() and require()' 
this isnt needed as the composer autoloader imports the files.

Removing these includes allows people to extend the classes if they want to..