### PR TITLE
check for ->tenantId instead of undefined  in FusionAuthClient.php

### DIFF
--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -2901,8 +2901,8 @@ class FusionAuthClient
   private function start()
   {
     $rest = new RESTClient();
-    if (isset($tenantId)) {
-      $rest->header("X-FusionAuth-TenantId", $tenantId);
+    if (isset($this->tenantId)) {
+      $rest->header("X-FusionAuth-TenantId", $this->tenantId);
     }
     return $rest->authorization($this->apiKey)
         ->url($this->baseURL)


### PR DESCRIPTION
Updated the check for tenantId to look for the tenantId property of the FusionAuthClient class.