### PR TITLE
update RESTClient to ensure bodyObject is in the correct format befor…

### DIFF
--- a/src/FusionAuth/RESTClient.php
+++ b/src/FusionAuth/RESTClient.php
@@ -380,6 +380,14 @@ class JSONBodyHandler implements BodyHandler
   public function __construct(&$bodyObject)
   {
     $this->bodyObject = $bodyObject;
+
+    if (is_string($bodyObject)) {
+      $bodyObject = json_decode($bodyObject);
+    }
+    if (is_object($bodyObject)) {
+      $bodyObject = (array) $bodyObject;
+    }
+
     $this->body = json_encode(array_filter($bodyObject));
   }
 


### PR DESCRIPTION
Some of the documentation/example implementations of the PHP client have issues when instantiating the JSONBodyHandler. This fix should ease those problems by ensuring the bodyObject passed to JSONBodyHandler as a param is unencoded if passed to the constructor as an encoded string. It also makes sure the bodyObject is an array before using array_filter.