### PR TITLE
CI/CD ENV fixes & include removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 package-lock.json
 /vendor
 /composer.lock
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ php:
 install:
   - composer install
 script:
-  - vendor/bin/phpunit --bootstrap vendor/autoload.php tests/FusionAuth/FusionAuthClientTest
+  - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  - '7.1'
+  - '7.2'
+  - '7.3'
+install:
+  - composer install
+script:
+  - export FUSIONAUTH_APIKEY=fusionauth-demoserver-apikey
+  - export FUSIONAUTH_BASEURL=https://fusionauth.devpoc.nl
+  - vendor/bin/phpunit --bootstrap vendor/autoload.php tests/FusionAuth/FusionAuthClientTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ php:
 install:
   - composer install
 script:
-  - export FUSIONAUTH_APIKEY=fusionauth-demoserver-apikey
-  - export FUSIONAUTH_BASEURL=https://fusionauth.devpoc.nl
   - vendor/bin/phpunit --bootstrap vendor/autoload.php tests/FusionAuth/FusionAuthClientTest

--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ if (!$result->wasSuccessful()) {
 
 // Hooray! Success
 ```
+
+
+#### Testing this library
+
+For unittesting, make sure the following environment variables are set:
+
+FUSIONAUTH_APIKEY, FUSIONAUTH_BASEURL
+
+To run the library's unit-tests simply run:
+
+``` composer test```

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-php-client", version: "1.9.3", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-php-client", version: "1.10.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
     "psr-4": {
       "FusionAuth\\": "src/FusionAuth/"
     }
+  },
+  "scripts": {
+    "test": "phpunit --bootstrap vendor/autoload.php tests/FusionAuth/FusionAuthClientTest"
   }
 }

--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -57,7 +57,7 @@ class FusionAuthClient
 
   public function __construct($apiKey, $baseURL)
   {
-    include_once 'RESTClient.php';
+    //include_once 'RESTClient.php';
     $this->apiKey = $apiKey;
     $this->baseURL = $baseURL;
   }

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -109,7 +109,7 @@ final class FusionAuthClientTest extends TestCase
     $this->assertEquals($response->successResponse->user->email, "test".$randomId."@fusionauth.io");
 
     // Login
-    $response = $this->client->login(["loginId" => "test@fusionauth.io", "password" => "password"]);
+    $response = $this->client->login(["loginId" => "test".$randomId."@fusionauth.io", "password" => "password"]);
     $this->handleResponse($response);
     $this->assertEquals($response->successResponse->user->email, "test".$randomId."@fusionauth.io");
 

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -20,13 +20,6 @@ final class FusionAuthClientTest extends TestCase
 
   public function setUp()
   {
-      /*
-       * Use enviroment vars for testing.
-       * FUSIONAUTH_APIKEY='fusionauth-demoserver-apikey'
-       * FUSIONAUTH_BASEURL='https://fusionauth.devpoc.nl/'
-       *
-       */
-
       $this->client = new FusionAuthClient(getenv('FUSIONAUTH_APIKEY'), getenv('FUSIONAUTH_BASEURL'));
   }
 

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -38,8 +38,9 @@ final class FusionAuthClientTest extends TestCase
 
   public function test_applications()
   {
+    $randomId = rand(0,100);
     // Create it
-    $response = $this->client->createApplication(null, ["application" => ["name" => "PHP Client Application"]]);
+    $response = $this->client->createApplication(null, ["application" => ["name" => "PHP Client Application".$randomId ]]);
     $this->handleResponse($response);
     $this->applicationId = $response->successResponse->application->id;
 
@@ -49,14 +50,14 @@ final class FusionAuthClientTest extends TestCase
     $this->assertEquals($response->successResponse->application->name, "PHP Client Application");
 
     // Update it
-    $response = $this->client->updateApplication($this->applicationId, [ "application" => ["name" => "PHP Client Application Updated"]]);
+    $response = $this->client->updateApplication($this->applicationId, [ "application" => ["name" => "PHP Client Application Updated".$randomId]]);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->application->name, "PHP Client Application Updated");
+    $this->assertEquals($response->successResponse->application->name, "PHP Client Application Updated".$randomId);
 
     // Retrieve it again
     $response = $this->client->retrieveApplication($this->applicationId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->application->name, "PHP Client Application Updated");
+    $this->assertEquals($response->successResponse->application->name, "PHP Client Application Updated".$randomId);
 
     // Deactivate it
     $response = $this->client->deactivateApplication($this->applicationId);
@@ -69,7 +70,7 @@ final class FusionAuthClientTest extends TestCase
 
     // Retrieve inactive
     $response = $this->client->retrieveInactiveApplications();
-    $this->assertEquals($response->successResponse->applications[0]->name, "PHP Client Application Updated");
+    $this->assertEquals($response->successResponse->applications[0]->name, "PHP Client Application Updated".$randomId);
 
     // Reactivate it
     $response = $this->client->reactivateApplication($this->applicationId);
@@ -78,7 +79,7 @@ final class FusionAuthClientTest extends TestCase
     // Retrieve it again
     $response = $this->client->retrieveApplication($this->applicationId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->application->name, "PHP Client Application Updated");
+    $this->assertEquals($response->successResponse->application->name, "PHP Client Application Updated".$randomId);
     $this->assertTrue($response->successResponse->application->active);
 
     // Delete it

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -47,7 +47,7 @@ final class FusionAuthClientTest extends TestCase
     // Retrieve it
     $response = $this->client->retrieveApplication($this->applicationId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->application->name, "PHP Client Application");
+    $this->assertEquals($response->successResponse->application->name, "PHP Client Application\".$randomId );
 
     // Update it
     $response = $this->client->updateApplication($this->applicationId, [ "application" => ["name" => "PHP Client Application Updated".$randomId]]);

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -2,10 +2,7 @@
 namespace fusionauth;
 
 use PHPUnit\Framework\TestCase;
-
-require_once __DIR__ . '/../../src/FusionAuth/FusionAuthClient.php';
-require_once __DIR__ . '/../../src/FusionAuth/RESTClient.php';
-require_once __DIR__ . '/../../src/FusionAuth/ClientResponse.php';
+use FusionAuth\FusionAuthClient;
 
 /**
  * @covers FusionAuthClient
@@ -23,7 +20,14 @@ final class FusionAuthClientTest extends TestCase
 
   public function setUp()
   {
-    $this->client = new FusionAuthClient('bf69486b-4733-4470-a592-f1bfce7af580', 'http://localhost:9011');
+      /*
+       * Use enviroment vars for testing.
+       * FUSIONAUTH_APIKEY='fusionauth-demoserver-apikey'
+       * FUSIONAUTH_BASEURL='https://fusionauth.devpoc.nl/'
+       *
+       */
+
+      $this->client = new FusionAuthClient(getenv('FUSIONAUTH_APIKEY'), getenv('FUSIONAUTH_BASEURL'));
   }
 
   public function tearDown()

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -96,30 +96,31 @@ final class FusionAuthClientTest extends TestCase
 
   public function test_users()
   {
+    $randomId = rand(0,100);
     // Create it
-    $response = $this->client->createUser(null, ["user" => ["email" => "test@fusionauth.io", "password" => "password", "firstName" => "Jäne"]]);
+    $response = $this->client->createUser(null, ["user" => ["email" => "test".$randomId."@fusionauth.io", "password" => "password", "firstName" => "Jäne"]]);
     $this->handleResponse($response);
     $this->userId = $response->successResponse->user->id;
 
     // Retrieve it
     $response = $this->client->retrieveUser($this->userId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->user->email, "test@fusionauth.io");
+    $this->assertEquals($response->successResponse->user->email, "test".$randomId."@fusionauth.io");
 
     // Login
     $response = $this->client->login(["loginId" => "test@fusionauth.io", "password" => "password"]);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->user->email, "test@fusionauth.io");
+    $this->assertEquals($response->successResponse->user->email, "test".$randomId."@fusionauth.io");
 
     // Update it
-    $response = $this->client->updateUser($this->userId, [ "user" => ["email" => "test+2@fusionauth.io"]]);
+    $response = $this->client->updateUser($this->userId, [ "user" => ["email" => "test".$randomId."_renamed@fusionauth.io"]]);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->user->email, "test+2@fusionauth.io");
+    $this->assertEquals($response->successResponse->user->email, "test".$randomId."_renamed@fusionauth.io");
 
     // Retrieve it again
     $response = $this->client->retrieveUser($this->userId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->user->email, "test+2@fusionauth.io");
+    $this->assertEquals($response->successResponse->user->email, "test".$randomId."_renamed@fusionauth.io");
 
     // Deactivate it
     $response = $this->client->deactivateUser($this->userId);
@@ -137,7 +138,7 @@ final class FusionAuthClientTest extends TestCase
     // Retrieve it again
     $response = $this->client->retrieveUser($this->userId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->user->email, "test+2@fusionauth.io");
+    $this->assertEquals($response->successResponse->user->email, "test".$randomId."_renamed@fusionauth.io");
     $this->assertTrue($response->successResponse->user->active);
 
     // Delete it

--- a/tests/FusionAuth/FusionAuthClientTest.php
+++ b/tests/FusionAuth/FusionAuthClientTest.php
@@ -47,7 +47,7 @@ final class FusionAuthClientTest extends TestCase
     // Retrieve it
     $response = $this->client->retrieveApplication($this->applicationId);
     $this->handleResponse($response);
-    $this->assertEquals($response->successResponse->application->name, "PHP Client Application\".$randomId );
+    $this->assertEquals($response->successResponse->application->name, "PHP Client Application".$randomId );
 
     // Update it
     $response = $this->client->updateApplication($this->applicationId, [ "application" => ["name" => "PHP Client Application Updated".$randomId]]);


### PR DESCRIPTION
i added **getenv()**  for the testing scripts.
also, the composer.json now contains the test-script command,  tests can be run by:  **composer test**


a  travis.yml was added for automated unit-testing.
The test-scripts now also have a unique identifier, in order not to fail during parallel testing in travis ( unique userid/applicationid)
