### PR TITLE
Fix method header

### DIFF
--- a/src/FusionAuth/RESTClient.php
+++ b/src/FusionAuth/RESTClient.php
@@ -259,7 +259,7 @@ class RESTClient
 
   public function header($name, $value)
   {
-    $this->headers[$name] = $value;
+    $this->headers[] = $name . ': ' . $value;
     return $this;
   }
 


### PR DESCRIPTION
Fix method header causing issues when using withTenantId on FusionAuthClient.