### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-php-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-php-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-php-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-php-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -2683,6 +2683,22 @@ class FusionAuthClient
   }
 
   /**
+   * Creates a preview of the message template provided in the request, normalized to a given locale.
+   *
+   * @param array $request The request that contains the email template and optionally a locale to render it in.
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function retrieveMessageTemplatePreview($request)
+  {
+    return $this->start()->uri("/api/message/template/preview")
+        ->bodyHandler(new JSONBodyHandler($request))
+        ->post()
+        ->go();
+  }
+
+  /**
    * Retrieves all of the message templates.
    *
    *

--- a/src/FusionAuth/FusionAuthClient.php
+++ b/src/FusionAuth/FusionAuthClient.php
@@ -412,6 +412,24 @@ class FusionAuthClient
   }
 
   /**
+   * Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+   *
+   * @param string $messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+   * @param array $request The request object that contains all of the information used to create the message template.
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function createMessageTemplate($messageTemplateId, $request)
+  {
+    return $this->start()->uri("/api/message/template")
+        ->urlSegment($messageTemplateId)
+        ->bodyHandler(new JSONBodyHandler($request))
+        ->post()
+        ->go();
+  }
+
+  /**
    * Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
    *
    * @param string $tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -820,6 +838,22 @@ class FusionAuthClient
   {
     return $this->start()->uri("/api/lambda")
         ->urlSegment($lambdaId)
+        ->delete()
+        ->go();
+  }
+
+  /**
+   * Deletes the message template for the given Id.
+   *
+   * @param string $messageTemplateId The Id of the message template to delete.
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function deleteMessageTemplate($messageTemplateId)
+  {
+    return $this->start()->uri("/api/message/template")
+        ->urlSegment($messageTemplateId)
         ->delete()
         ->go();
   }
@@ -1660,6 +1694,24 @@ class FusionAuthClient
   {
     return $this->start()->uri("/api/lambda")
         ->urlSegment($lambdaId)
+        ->bodyHandler(new JSONBodyHandler($request))
+        ->patch()
+        ->go();
+  }
+
+  /**
+   * Updates, via PATCH, the message template with the given Id.
+   *
+   * @param string $messageTemplateId The Id of the message template to update.
+   * @param array $request The request that contains just the new message template information.
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function patchMessageTemplate($messageTemplateId, $request)
+  {
+    return $this->start()->uri("/api/message/template")
+        ->urlSegment($messageTemplateId)
         ->bodyHandler(new JSONBodyHandler($request))
         ->patch()
         ->go();
@@ -2610,6 +2662,36 @@ class FusionAuthClient
         ->urlParameter("applicationId", $applicationId)
         ->urlParameter("start", $start)
         ->urlParameter("end", $end)
+        ->get()
+        ->go();
+  }
+
+  /**
+   * Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+   *
+   * @param string $messageTemplateId (Optional) The Id of the message template.
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function retrieveMessageTemplate($messageTemplateId = NULL)
+  {
+    return $this->start()->uri("/api/message/template")
+        ->urlSegment($messageTemplateId)
+        ->get()
+        ->go();
+  }
+
+  /**
+   * Retrieves all of the message templates.
+   *
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function retrieveMessageTemplates()
+  {
+    return $this->start()->uri("/api/message/template")
         ->get()
         ->go();
   }
@@ -3713,6 +3795,24 @@ class FusionAuthClient
   {
     return $this->start()->uri("/api/lambda")
         ->urlSegment($lambdaId)
+        ->bodyHandler(new JSONBodyHandler($request))
+        ->put()
+        ->go();
+  }
+
+  /**
+   * Updates the message template with the given Id.
+   *
+   * @param string $messageTemplateId The Id of the message template to update.
+   * @param array $request The request that contains all of the new message template information.
+   *
+   * @return ClientResponse The ClientResponse.
+   * @throws \Exception
+   */
+  public function updateMessageTemplate($messageTemplateId, $request)
+  {
+    return $this->start()->uri("/api/message/template")
+        ->urlSegment($messageTemplateId)
         ->bodyHandler(new JSONBodyHandler($request))
         ->put()
         ->go();


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`