### PR TITLE
fix: handle curl errors like outages and timeouts

### DIFF
--- a/src/FusionAuth/RESTClient.php
+++ b/src/FusionAuth/RESTClient.php
@@ -251,6 +251,10 @@ class RESTClient
 
             $result = curl_exec($curl);
 
+            if (curl_errno($curl)) {
+                throw new \Exception(curl_error($curl), curl_errno($curl));
+            }
+
             $response->status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
             if ($response->status < 200 || $response->status > 299) {
                 if ($result) {


### PR DESCRIPTION
As described in https://github.com/FusionAuth/fusionauth-php-client/issues/28 cURL errors like timeouts, unresolved domains or server outages are not handled so from outside the library there is no way to know what went wrong. This PR checks if any cURL error occurred before continuing and throws a proper exception indicating the issue.