### PR TITLE
Remove curl_close calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     }
   ],
   "require": {
+    "php": ">=8.0",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/src/FusionAuth/RESTClient.php
+++ b/src/FusionAuth/RESTClient.php
@@ -261,14 +261,8 @@ class RESTClient
                     $response->successResponse = $this->successResponseHandler->call($result);
                 }
             }
-
-            curl_close($curl);
             return $response;
         } catch (\Exception $e) {
-            if (isset($curl)) {
-                curl_close($curl);
-            }
-
             $response->exception = $e;
             return $response;
         }


### PR DESCRIPTION
This PR removes explicit curl_close($curl) calls from RESTClient.php.

In PHP 8.0 and later, cURL handles are represented by CurlHandle objects instead of resources. As a result, curl_close() no longer has any effect. Starting with PHP 8.5, calling curl_close() also triggers a deprecation warning.

Before PHP 8.0, curl_close() was still required to explicitly close cURL resources. Since removing these calls drops compatibility with PHP versions older than 8.0, the minimum PHP requirement for this package has been updated to PHP 8.0.